### PR TITLE
Simplify partition setup (didn't work)

### DIFF
--- a/scripts/hyperv/Autounattend.xml
+++ b/scripts/hyperv/Autounattend.xml
@@ -32,6 +32,7 @@
                             <PartitionID>1</PartitionID>
                             <Label>WINRE</Label>
                             <Format>NTFS</Format>
+                            <TypeID>de94bba4-06d1-4d40-a16a-bfd50179d6ac</TypeID>
                         </ModifyPartition>
                         <ModifyPartition wcm:action="add">
                             <Active>true</Active>


### PR DESCRIPTION
DOC:
* https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-setup-diskconfiguration-disk
* https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions

### Based on BIOS (non-UEFI) samples
* https://github.com/StefanScherer/packer-windows/blob/main/answer_files/2025/Autounattend.xml
* https://github.com/MattHodge/PackerTemplates/blob/master/answer_files/win2016std/Autounattend.xml

GitHub search: https://github.com/search?q=de94bba4-06d1-4d40-a16a-bfd50179d6ac+path%3A*.xml&type=code


## Observed problem
Installation stuck at this screen  
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/04190fc8-eefb-4b72-9e06-5a7b2000adec" />

This is probably because a "BIOS" partition layout isn't compatible with "UEFI" systems.
