### PR TITLE
Replace PsExec with scheduled task

### DIFF
--- a/windows-builder.pkr.hcl
+++ b/windows-builder.pkr.hcl
@@ -163,10 +163,13 @@ build {
     inline = ["C:\\Install\\InstallNuGet.ps1"]
   }
 
-  provisioner "windows-shell" {
+  provisioner "powershell" {
+    # Configure NuGet for System account
     inline = [
-      # Configure NuGet for System account
-      "C:\\Install\\psexec64.exe -accepteula -s powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command \"$env:NUGET_REPO_URL='${var.NUGET_REPO_URL}'; $env:NUGET_REPO_USER='${var.NUGET_REPO_USER}'; $env:NUGET_REPO_PW='${var.NUGET_REPO_PW}'; C:\\Install\\ConfigureNuGet.ps1\""
+      "$action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument \"-Command `\" `$env:NUGET_REPO_URL='${var.NUGET_REPO_URL}'; `$env:NUGET_REPO_USER='${var.NUGET_REPO_USER}'; `$env:NUGET_REPO_PW='${var.NUGET_REPO_PW}'; C:\\Install\\ConfigureNuGet.ps1 `\" \"",
+      "Register-ScheduledTask -Action $action -User \"System\" -TaskName \"NuGet configure\" -Description \"Configure NuGet package sources\"",
+      "Start-ScheduledTask -TaskName \"NuGet configure\"",
+      #"Unregister-ScheduledTask -TaskName \"NuGet configure\" -Confirm:$false"
     ]
   }
 


### PR DESCRIPTION
Resolves #44

### Command parsing details
Input:
```
"$action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument \"-Command `\" `$env:NUGET_REPO_URL='${var.NUGET_REPO_URL}'; `$env:NUGET_REPO_USER='${var.NUGET_REPO_USER}'; `$env:NUGET_REPO_PW='${var.NUGET_REPO_PW}'; C:\\Install\\ConfigureNuGet.ps1 `\" \"",
```

Packer-processed:  
```
$action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument "-Command `" `$env:NUGET_REPO_URL='${var.NUGET_REPO_URL}'; `$env:NUGET_REPO_USER='${var.NUGET_REPO_USER}'; `$env:NUGET_REPO_PW='${var.NUGET_REPO_PW}'; C:\Install\ConfigureNuGet.ps1 `" "
```

Outcome:  
<img width="918" height="28" alt="image" src="https://github.com/user-attachments/assets/04e6834f-fd89-4b87-9228-4c0a54e67953" />


## Documentation
* Packet HCL escape characters: https://developer.hashicorp.com/packer/docs/templates/hcl_templates/expressions#string-literals
